### PR TITLE
Feature: Update minioclient installation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,9 +40,6 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Pull existing image from ECR as cache
-        run: docker pull ${{ steps.login-ecr.outputs.registry }}/reports:latest || true
-
       - name: Set image tag based on branch
         id: set-tag
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
         id: set-tag
         run: |
           if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]; then
-            echo "IMAGE_TAG=latest" >> $GITHUB_OUTPUT
+            echo "IMAGE_TAG=prod" >> $GITHUB_OUTPUT
           elif [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/develop" ]]; then
             echo "IMAGE_TAG=staging" >> $GITHUB_OUTPUT
           else
@@ -67,15 +67,43 @@ jobs:
             echo "TAG_EXISTS=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Fetch the latest image tag from Amazon ECR
+        id: latest-tag
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: reports
+          AWS_REGION: us-west-1
+        run: |
+          LATEST_TAG=$(aws ecr describe-images \
+            --repository-name $ECR_REPOSITORY \
+            --region $AWS_REGION \
+            --query 'sort_by(imageDetails,& imagePushedAt)[-1].imageTags[0]' \
+            --output text)
+          echo "LATEST_TAG=$LATEST_TAG" >> $GITHUB_OUTPUT
+
+      - name: Pull the latest image for cache
+        if: steps.latest-tag.outputs.LATEST_TAG != 'None'
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: reports
+        run: |
+          docker pull $ECR_REGISTRY/$ECR_REPOSITORY:${{ steps.latest-tag.outputs.LATEST_TAG }}
+
       - name: Build, tag, and push image to Amazon ECR
         if: steps.check-tag.outputs.TAG_EXISTS == 'false'
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: reports
           IMAGE_TAG: ${{ github.sha }}
+          LABEL_TAG: ${{ steps.set-tag.outputs.IMAGE_TAG }}
         run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG . \
+            --cache-from $ECR_REGISTRY/$ECR_REPOSITORY:${{ steps.latest-tag.outputs.LATEST_TAG }}
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          # Tag the same image as 'prod' or 'staging'
+          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:$LABEL_TAG
+          # Push the 'LABEL_TAG' tag
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$LABEL_TAG
 
       - name: Determine Secret Name
         id: set-secret-name

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,5 +66,9 @@ RUN conda run -n reports /bin/bash -c "Rscript /tmp/install_biocmanager.R"
 RUN wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/local/bin/mc && \
   chmod +x /usr/local/bin/mc
 
+# Create a symlink for mc binary to be accessible as expected by minioclient
+RUN mkdir -p /root/.local/share/R/minioclient/ && \
+  ln -s /usr/local/bin/mc /root/.local/share/R/minioclient/mc
+
 # Set the working directory
 WORKDIR /home/ubuntu/eDNAExplorer


### PR DESCRIPTION
This resolves the issue blocking the GBIF_Pull.R script from running on our containers in Kubernetes. I had to simply symlink the default mc installation to where the R script is expecting it to be. We do not have control over the internals of the gbif local library pulling the strings to this is our quick fix.

Also updated the build process to retag images as staging or prod in addition to using the sha. The actions file will pull the latest image and use that as the cached image for the build process.